### PR TITLE
Frontmatter changes for section committee review

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -484,7 +484,7 @@ in order to more clearly identify these calls as performing atomic operations.
 In addition, the abbreviated names ``cswap'', ``finc'', and ``fadd'' were
 expanded for clarity to ``compare\_swap'', ``fetch\_inc'', and ``fetch\_add''.
 
-\subsection{SMA\_* Environment Variables}
+\subsection{SMA\_* Environment Variables}\label{subsec:deprecate-sma-env}
 The environment variables
 \begin{center}
 \begin{tabular}{ll}

--- a/content/environment_variables.tex
+++ b/content/environment_variables.tex
@@ -3,7 +3,9 @@ users to configure the \openshmem implementation, and receive information about
 the implementation. The implementations of the specification are free to define
 additional variables. Currently, the specification defines four environment
 variables. All environment variables that start with \VAR{SMA\_*} are
-deprecated, but currently supported for backwards compatibility.
+deprecated, but currently supported for backwards compatibility. Refer to the
+\hyperref[subsec:deprecate-sma-env]{SMA\_* Environment Variables} deprecation
+rationale for more details.
 
 \medskip{}
 

--- a/content/execution_model.tex
+++ b/content/execution_model.tex
@@ -29,9 +29,9 @@ The \openshmem model assumes that computation and communication are naturally
 overlapped. \openshmem programs are expected to exhibit progression of
 communication both with and without \openshmem calls. Consider a \ac{PE} that is
 engaged in a computation with no \openshmem calls. Other \acp{PE} should be able
-to communicate (\OPR{put}, \OPR{get}, \OPR{collective}, \OPR{atomic}, etc) and
+to communicate (\OPR{put}, \OPR{get}, \OPR{atomic}, etc) and
 complete communication operations with that computationally-bound \ac{PE}
-without that \ac{PE} issuing any explicit \openshmem calls. \openshmem
+without that \ac{PE} issuing any explicit \openshmem calls. One-sided \openshmem
 communication calls involving that \ac{PE} should progress regardless of when
 that \ac{PE} next engages in an \openshmem call.
 

--- a/content/execution_model.tex
+++ b/content/execution_model.tex
@@ -1,5 +1,5 @@
 An \openshmem program consists of a set of \openshmem processes called \acp{PE}
-that execute in a \ac{SPMD}-like model where each \ac{PE} can take a different
+that execute in an \ac{SPMD}-like model where each \ac{PE} can take a different
 execution path. For example, a \ac{PE} can be implemented using an OS
 process.  The \acp{PE} progress asynchronously, and can communicate/synchronize
 via the \openshmem interfaces.  All \acp{PE} in an \openshmem program should
@@ -17,7 +17,7 @@ behavior.
 
 The \acp{PE} of the \openshmem program are identified by unique integers.  The
 identifiers are integers assigned in a monotonically increasing manner from zero
-to the total number of \acp{PE} minus 1. \ac{PE} identifiers are used for
+to one less than the total number of \acp{PE}. \ac{PE} identifiers are used for
 \openshmem calls (e.g. to specify \OPR{put} or \OPR{get} routines on symmetric
 data objects, collective synchronization calls) or to dictate a control flow for
 \acp{PE} using constructs of \Cstd or \Fortran. The identifiers are fixed for

--- a/content/execution_model.tex
+++ b/content/execution_model.tex
@@ -11,7 +11,7 @@ program concludes its use of the \openshmem library when all \acp{PE} call
 when any \ac{PE} calls \FUNC{shmem\_global\_exit}.
 During a call to \FUNC{shmem\_finalize}, the \openshmem library must
 complete all pending communication and release all the resources associated to
-the library using an implicit collective synchronization across PEs.
+the library using an implicit collective synchronization across \acp{PE}.
 Calling any \openshmem routine after \FUNC{shmem\_finalize} leads to undefined
 behavior.
 

--- a/content/execution_model.tex
+++ b/content/execution_model.tex
@@ -4,7 +4,7 @@ execution path. For example, a \ac{PE} can be implemented using an OS
 process.  The \acp{PE} progress asynchronously, and can communicate/synchronize
 via the \openshmem interfaces.  All \acp{PE} in an \openshmem program should
 start by calling the initialization routine  \FUNC{shmem\_init}
-\footnote{\textbf{start\_pes} has been deprecated as of Specification 1.2}
+\footnote{\FUNC{start\_pes} has been deprecated as of \openshmem[1.2]}
 before using any of the other \openshmem library routines.  An \openshmem
 program concludes its use of the \openshmem library when all \acp{PE} call
 \FUNC{shmem\_finalize}. An \openshmem program can also be terminated

--- a/content/language_bindings_and_conformance.tex
+++ b/content/language_bindings_and_conformance.tex
@@ -1,6 +1,6 @@
 \openshmem provides ISO \Cstd and \Fortran[90] language bindings.
-As of \openshmem[1.4], the \Fortran API is deprecated and should be expected
-to be removed in a future specification. For rationale and considerations of
+As of \openshmem[1.4], the \Fortran API is deprecated.
+For rationale and considerations of
 future \Fortran use of \openshmem, see Section~\ref{subsec:deprecate-fortran}.
 
 Any implementation that provides both \Cstd and \Fortran bindings can claim

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -1,7 +1,7 @@
-The constants that start with SHMEM\_* are for both \Fortran
+The constants that start with \CONST{SHMEM\_*} are for both \Fortran
 and \CorCpp, and they are compile-time constants. 
 All constants that start with
-\_SHMEM\_* are deprecated and provided for backwards compatibility.
+\CONST{\_SHMEM\_*} are deprecated and provided for backwards compatibility.
 \newline
 \newline
 \begin{tabular}{|p{0.4\textwidth}|p{0.5\textwidth}|}

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -12,7 +12,7 @@ via \openshmem routines. Private data objects follow the memory model of
 \Cstd or \Fortran. Remotely accessible objects, however, can be accessed by
 remote \acp{PE} using \openshmem routines.  Remotely accessible data objects are
 called \emph{Symmetric Data Objects}.  Each symmetric data object has a
-corresponding object with the same name, type, and size on all PEs where that object is
+corresponding object with the same name, type, and size on all \acp{PE} where that object is
 accessible via the \openshmem \ac{API}\footnote{For efficiency reasons,
 the same offset (from an arbitrary memory address) for symmetric data
 objects might be used on all \acp{PE}. Further discussion about symmetric heap

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -21,7 +21,7 @@ layout and implementation efficiency can be found in section
 descriptions for \FUNC{shmem\_pe\_accessible} and \FUNC{shmem\_addr\_accessible}
 in sections \ref{subsec:shmem_pe_accessible} and
 \ref{subsec:shmem_addr_accessible}.) Symmetric data objects accessed via typed
-\openshmem interfaces are required to be natural aligned based on their type
+\openshmem interfaces are required to be naturally aligned based on their type
 requirements and underlying architecture.  In \openshmem the following kinds of
 data objects are symmetric:
 %

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -37,7 +37,8 @@ data objects are symmetric:
   \begin{deprecate}
     \Fortran arrays allocated with \FUNC{shpalloc}
   \end{deprecate}
-\item \Cstd and \Cpp data allocated by \FUNC{shmem\_malloc}
+\item \Cstd and \Cpp data allocated by \openshmem memory management routines
+  (Section~\ref{sec:memory_management})
 \end{itemize}       
 
 \openshmem dynamic memory allocation routines (\FUNC{shpalloc} and

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -20,8 +20,7 @@ into multiple sub-problems that can be solved independently or with coordination
 using the communication and synchronization interfaces.  The \openshmem
 specification defines library calls, constants, variables, and language bindings
 for \Cstd and \Fortran.%
-\footnote{As of \openshmem[1.4], the \Fortran interface has been deprecated
-  and should be expected to be removed in a future release.}.
+\footnote{As of \openshmem[1.4], the \Fortran interface has been deprecated.}.
 The \Cpp interface is currently the same as that
 for \Cstd. Unlike UPC, \Fortran[2008], Titanium, X10 and Chapel, which are all
 PGAS languages, \openshmem relies on the user to use the library calls  to

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -1,6 +1,6 @@
 \openshmem implements \ac{PGAS} by defining remotely accessible data objects as
-mechanisms to share information among \openshmem processes or \acp{PE} and
-private data objects that are accessible by the \ac{PE} itself. The \ac{API}
+mechanisms to share information among \openshmem processes or \acp{PE}, and
+private data objects that are accessible by only the \ac{PE} itself. The \ac{API}
 allows communication and synchronization operations on both private (local to
 the PE initiating the operation) and remotely accessible data objects. The key
 feature of \openshmem is that data transfer operations are
@@ -22,7 +22,7 @@ specification defines library calls, constants, variables, and language bindings
 for \Cstd and \Fortran.%
 \footnote{As of \openshmem[1.4], the \Fortran interface has been deprecated.}.
 The \Cpp interface is currently the same as that
-for \Cstd. Unlike Unified Parallel C, \Fortran[2008], Titanium, X10 and Chapel, which are all
+for \Cstd. Unlike Unified Parallel C, \Fortran[2008], Titanium, X10, and Chapel, which are all
 PGAS languages, \openshmem relies on the user to use the library calls  to
 implement the correct semantics of its programming model.
 
@@ -87,7 +87,7 @@ An overview of the \openshmem routines is described below:
   \PUT, AMO, and memory store operations
   to symmetric data objects with respect to a specific
       destination \ac{PE}. 
-  \item \OPR{Quiet}: The \ac{PE} calling quiet ensures completion of remote access
+  \item \OPR{Quiet}: The \ac{PE} calling quiet ensures remote completion of remote access
       operations and stores to symmetric data objects. 
   \item \OPR{Barrier}: All or some \acp{PE} collectively synchronize and ensure
       completion of all remote and local updates prior to any \ac{PE} returning

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -22,7 +22,7 @@ specification defines library calls, constants, variables, and language bindings
 for \Cstd and \Fortran.%
 \footnote{As of \openshmem[1.4], the \Fortran interface has been deprecated.}.
 The \Cpp interface is currently the same as that
-for \Cstd. Unlike UPC, \Fortran[2008], Titanium, X10 and Chapel, which are all
+for \Cstd. Unlike Unified Parallel C, \Fortran[2008], Titanium, X10 and Chapel, which are all
 PGAS languages, \openshmem relies on the user to use the library calls  to
 implement the correct semantics of its programming model.
 

--- a/content/the_openshmem_effort.tex
+++ b/content/the_openshmem_effort.tex
@@ -3,8 +3,8 @@ provide a standard \ac{API} for SHMEM libraries to aid portability and
 facilitate uniform predictable results of \openshmem programs by explicitly
 stating the behavior and semantics of the \openshmem library calls. Through the
 different versions, \openshmem will continue to address the requirements of the
-\ac{PGAS} community.  As of this specification, existing vendors are moving
-towards \openshmem compliant implementations and new vendors are developing
+\ac{PGAS} community.  As of this specification, many existing vendors support
+\openshmem-compliant implementations and new vendors are developing
 \openshmem library implementations to help the users write portable \openshmem
 code. This ensures that programs can run on multiple platforms without having to
 deal with subtle vendor-specific implementation differences. For more details on

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -83,7 +83,7 @@ environment of the \acp{PE}.
 
 
 
-\subsection{Memory Management Routines}
+\subsection{Memory Management Routines}\label{sec:memory_management}
 \openshmem provides a set of \acp{API} for managing the symmetric heap. The
 \acp{API} allow one to dynamically allocate, deallocate, reallocate and align
 symmetric data objects in the symmetric heap, in \Cstd and \Fortran.


### PR DESCRIPTION
This PR includes:
* LaTeX styling and minor grammar fixes
* Tweak to Fortran deprecation text for consistency with other API deprecation notes
* A correction to the Execution Model section that implied a collective operation could progress without participation of one of the PEs in the collective
* Some consistency edits
* The emailed patch from @agrippa

Tagging for section committee review: @RaymondMichael @spophale @BryantLam @agrippa @tonycurtis