### PR TITLE
section/front: Table Formatting

### DIFF
--- a/content/environment_variables.tex
+++ b/content/environment_variables.tex
@@ -14,19 +14,18 @@ deprecation rationale for more details.
 
 \begin{tabular}{|l|l|l|}
 \hline 
-Variable & Value & Purpose\tabularnewline
+\textbf{Variable} & \textbf{Value} & \textbf{Description}\tabularnewline
 \hline 
-\hline 
-\VAR{SHMEM\_VERSION} & any & print the library version at
+\VAR{SHMEM\_VERSION} & Any & Print the library version at
 start-up\tabularnewline
 \hline 
-\VAR{SHMEM\_INFO} & any & print helpful text about all these environment
+\VAR{SHMEM\_INFO} & Any & Print helpful text about all these environment
 variables\tabularnewline
 \hline 
-\VAR{SHMEM\_SYMMETRIC\_SIZE} & non-negative integer & number of bytes to
+\VAR{SHMEM\_SYMMETRIC\_SIZE} & Non-negative integer & Number of bytes to
 allocate for symmetric heap\tabularnewline
 \hline 
-\VAR{SHMEM\_DEBUG} & any & enable debugging messages\tabularnewline
+\VAR{SHMEM\_DEBUG} & Any & Enable debugging messages\tabularnewline
 \hline 
 \end{tabular}
 

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -2,28 +2,29 @@ The constants that start with \CONST{SHMEM\_*} are for both \Fortran
 and \CorCpp, and they are compile-time constants.
 All constants that start with
 \CONST{\_SHMEM\_*} are deprecated and provided for backwards compatibility.
-\newline
-\newline
-\begin{tabular}{|p{0.4\textwidth}|p{0.5\textwidth}|}
+
+\begin{longtable}{|p{0.45\textwidth}|p{0.5\textwidth}|}
 \hline
 \textbf{Constant} & \textbf{Description}
 \tabularnewline
 \hline
-\hline
-%new
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_SYNC\_SIZE}}}
+\endhead
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_SYNC\_SIZE}
+\\~}
 & Length of a work array that can be used with any SHMEM collective
 communication operation. The value of this constant is implementation
 specific. Refer to the individual \hyperref[subsec:coll]{Collective Routines} for more information
 about the usage of this constant. Work arrays sized for specific operations may
 consume less memory.\tabularnewline
-%new
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_BCAST\_SYNC\_SIZE}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_BCAST\_SYNC\_SIZE}
+\\~}
 &
 Length of the \VAR{pSync} arrays needed for broadcast routines. The value
 of this constant is implementation specific. Refer to the
@@ -31,16 +32,20 @@ of this constant is implementation specific. Refer to the
 \hyperref[sec:openshmem_library_api]{Library Routines} for more information
 about the usage of this constant. \tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_SYNC\_VALUE}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_SYNC\_VALUE}
+\\~}
 &
 The value used to initialize the elements of \VAR{pSync} arrays. The
 value of this constant is implementation specific.\tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}
+\\~}
 &
 Length of the work arrays needed for reduction routines. The value
 of this constant is implementation specific. Refer to the
@@ -48,9 +53,11 @@ of this constant is implementation specific. Refer to the
 \hyperref[sec:openshmem_library_api]{Library Routines} for more information
 about the usage of this constant.\tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}
+\\~}
 &
 Length of the work array needed for barrier routines. The value
 of this constant is implementation specific. Refer to the
@@ -58,9 +65,11 @@ of this constant is implementation specific. Refer to the
 \hyperref[sec:openshmem_library_api]{Library Routines}
 for more information about the usage of this constant.\tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}
+\\~}
 &
 Length of the work array needed for collect routines. The value
 of this constant is implementation specific. Refer to the
@@ -68,9 +77,11 @@ of this constant is implementation specific. Refer to the
 \hyperref[sec:openshmem_library_api]{Library Routines} for more information
 about the usage of this constant.\tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}
+\\~}
 &
 Length of the work array needed for \FUNC{shmem\_alltoall}
 routines. The value of this constant is implementation
@@ -78,13 +89,11 @@ specific. Refer to the \hyperref[subsec:shmem_alltoall]{Alltoall
 routines} sections under \hyperref[sec:openshmem_library_api]{Library Routines}
 for more information about the usage of this constant.\tabularnewline
 \hline
-\end{tabular}
-
-\begin{tabular}{|p{0.4\textwidth}|p{0.5\textwidth}|}
-\hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}
+\\~}
 &
 Length of the work array needed for \FUNC{shmem\_alltoalls}
 routines. The value of this constant is implementation
@@ -92,39 +101,42 @@ specific. Refer to the \hyperref[subsec:shmem_alltoalls]{Alltoalls
 routines} sections under \hyperref[sec:openshmem_library_api]{Library Routines}
 for more information about the usage of this constant.\tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE}
+\\~}
 & Minimum length of work arrays used in various collective routines.\tabularnewline
 \hline
-\vspace{3mm}
-%\color{red}
-%\vtop{\hbox{}
-%\hbox{\hspace*{12mm} \CONST{}}
-%\hbox{}
-%\hbox{\hspace*{12mm} \CONST{}}}
-%& \color{red}
-%Ticket \#107 \tabularnewline
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_MAJOR\_VERSION}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_MAJOR\_VERSION}
+\\~}
 &
 Integer representing the major version of \openshmem standard in use. \tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_MINOR\_VERSION}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_MINOR\_VERSION}
+\\~}
 &
 Integer representing the minor version of \openshmem standard in use. \tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_MAX\_NAME\_LEN}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_MAX\_NAME\_LEN}
+\\~}
 &
 Integer representing the maximum length of \CONST{SHMEM\_VENDOR\_STRING}. \tabularnewline
 \hline
-\vspace{3mm}
-\vtop{\hbox{\CorCppFor:}
-\hbox{\hspace*{12mm} \CONST{SHMEM\_VENDOR\_STRING}}}
+%%
+\parbox[t]{0pt}{~\\[-4pt]
+    \CorCppFor: \\\hspace*{8mm}
+    \CONST{SHMEM\_VENDOR\_STRING}
+\\~}
 &
 String representing vendor defined information of size at most
 \CONST{SHMEM\_MAX\_NAME\_LEN}.
@@ -132,6 +144,5 @@ In \CorCpp{}, the string is terminated by a null character.  In \Fortran, the
 string of size less than \CONST{SHMEM\_MAX\_NAME\_LEN} is padded with blank
 characters up to size \CONST{SHMEM\_MAX\_NAME\_LEN}. \tabularnewline
 \hline
-
-\end{tabular}
-\color{black}
+%%
+\end{longtable}


### PR DESCRIPTION
Table formatting for Library Constants and Environment Variables.

- Library Constants: Converted to longtable and changed formatting for first column. New table spacing should look slightly better than original and the LaTeX source should be easier to quickly scan through now.
- Environment Variables: Bold headings. Capitalized table entries.