### PR TITLE
Move SHMEM_CTX_DEFAULT to new library handles section

### DIFF
--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -36,14 +36,6 @@ may be multithreaded and any thread may invoke the \openshmem interfaces.
 See Section~\ref{subsec:thread_support} for more detail about its use.
 \tabularnewline \hline
 %%
-\LibConstDecl[\CorCpp]{SHMEM\_CTX\_DEFAULT} &
-Handle of type \CTYPE{shmem\_ctx\_t} that corresponds to the
-default communication context.  All point-to-point communication operations
-and synchronizations that do not specify a context are performed on the
-default context.
-See Section~\ref{sec:ctx} for more detail about its use.
-\tabularnewline \hline
-%%
 \LibConstDecl[\CorCpp]{SHMEM\_CTX\_SERIALIZED} &
 The context creation option which specifies that the given context
 is shareable but will not be used by multiple threads concurrently.

--- a/content/library_handles.tex
+++ b/content/library_handles.tex
@@ -1,0 +1,21 @@
+The \openshmem library provides a set of predefined named constant handles.
+All named constants can be used in initialization expressions or assignments,
+but not necessarily in array declarations or as labels in C switch statements.
+This implies named constants to be link-time but not necessarily compile-time
+constants.
+
+\begin{longtable}{|p{0.45\textwidth}|p{0.5\textwidth}|}
+\hline
+\textbf{Handle} & \textbf{Description}
+\tabularnewline \hline
+\endhead
+%%
+\LibConstDecl[\CorCpp]{SHMEM\_CTX\_DEFAULT} &
+Handle of type \CTYPE{shmem\_ctx\_t} that corresponds to the
+default communication context.  All point-to-point communication operations
+and synchronizations that do not specify a context are performed on the
+default context.
+See Section~\ref{sec:ctx} for more detail about its use.
+\tabularnewline \hline
+%%
+\end{longtable}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -30,6 +30,9 @@
 \section{Library Constants}\label{subsec:library_constants}
 \input{content/library_constants}
 
+\section{Library Handles}\label{subsec:library_handles}
+\input{content/library_handles}
+
 \section{Environment Variables }\label{subsec:environment_variables}
 \input{content/environment_variables}
 


### PR DESCRIPTION
Proposed change to make SHMEM_CTX_DEFAULT a link-time constant.

Please don't merge until this clears committee discussion at the 11/9 meeting.

PDF Preview: [main_spec.pdf](https://github.com/RaymondMichael/specification/files/1451875/main_spec.pdf)
