### PR TITLE
Frontmatter: replace default team with world team

### DIFF
--- a/content/library_handles.tex
+++ b/content/library_handles.tex
@@ -14,10 +14,10 @@ constants.
 \endhead
 %%
 \LibHandleDecl{SHMEM\_TEAM\_WORLD} &
-Handle of type \CTYPE{shmem\_team\_t} that corresponds to the
-default team of all \acp{PE} in the \openshmem program.  All point-to-point
+Handle of type \CTYPE{shmem\_team\_t} that corresponds to the world
+team that contains all \acp{PE} in the \openshmem program.  All point-to-point
 communication operations and collective synchronizations that do not specify a team
-are performed on the default team.
+are performed on the world team.
 See Section~\ref{subsec:team} for more detail about its use.
 \tabularnewline \hline
 %%


### PR DESCRIPTION
Use "world team" instead of "default team" in the definition of `SHMEM_TEAM_WORLD`. Address #317 for Section 7. Library Handles.