### PR TITLE
Frontmatter: Remove SHMEM_CACHE

### DIFF
--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -140,12 +140,4 @@ An overview of the \openshmem routines is described below:
       \VAR{lock} releases it.
 \end{enumerate}
 
-\begin{DeprecateBlock}
-\item \textbf{Data Cache Control}
-\begin{enumerate}
-  \item Implementation of mechanisms to exploit the capabilities of hardware cache
-      if available.
-\end{enumerate}
-\end{DeprecateBlock}
-
 \end{enumerate}


### PR DESCRIPTION
Related backmatter change in https://github.com/BryantLam/openshmem-specification/pull/9 removes SHMEM_CACHE from the specification. This PR is the frontmatter-specific removal from the Programming Model Overview, Chapter 2.